### PR TITLE
Force pylint version 1.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ deploy:
 install:
 - pip install -r requirements.txt
 - pip install pylint circuitpython-build-tools Sphinx sphinx-rtd-theme
+- pip install --force-reinstall pylint==1.9.2
 script:
 - pylint adafruit_bmp280.py
 - ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name examples/*.py)

--- a/adafruit_bmp280.py
+++ b/adafruit_bmp280.py
@@ -171,7 +171,6 @@ class Adafruit_BMP280_I2C(Adafruit_BMP280): # pylint: disable=invalid-name
     """Driver for I2C connected BMP280. Default address is 0x77 but another address can be passed
        in as an argument"""
     def __init__(self, i2c, address=0x77):
-        # pylint: disable=useless-import-alias
         import adafruit_bus_device.i2c_device as i2c_device
         self._i2c = i2c_device.I2CDevice(i2c, address)
         super().__init__()
@@ -195,7 +194,6 @@ class Adafruit_BMP280_SPI(Adafruit_BMP280):
     """Driver for SPI connected BMP280. Default clock rate is 100000 but can be changed with
       'baudrate'"""
     def __init__(self, spi, cs, baudrate=100000):
-        # pylint: disable=useless-import-alias
         import adafruit_bus_device.spi_device as spi_device
         self._spi = spi_device.SPIDevice(spi, cs, baudrate=baudrate)
         super().__init__()


### PR DESCRIPTION
I added forced reinstallation of pylint 1.9.2 to the .travis.yml, similar to many other Adafruit CircuitPython libraries.

I made this addition because it was listed under "PyLint version not fixed - 9" in https://github.com/adafruit/circuitpython/issues/1246