### PR TITLE
Add Adafruit-Blinka to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+Adafruit-Blinka
 adafruit-circuitpython-busdevice
 adafruit-circuitpython-register


### PR DESCRIPTION
Fix for issue listed in https://github.com/adafruit/circuitpython/issues/1246

> For pypi compatibility, missing Adafruit-Blinka in requirements.txt - 22