### PR TITLE
change CS pin to D5

### DIFF
--- a/examples/bmp280_normal_mode.py
+++ b/examples/bmp280_normal_mode.py
@@ -17,7 +17,7 @@ bmp280 = adafruit_bmp280.Adafruit_BMP280_I2C(i2c)
 
 # OR Create sensor object, communicating over the board's default SPI bus
 # spi = busio.SPI()
-# bmp_cs = digitalio.DigitalInOut(board.D10)
+# bmp_cs = digitalio.DigitalInOut(board.D5)
 # bmp280 = adafruit_bmp280.Adafruit_BMP280_SPI(spi, bmp_cs)
 
 # change this to match the location's pressure (hPa) at sea level

--- a/examples/bmp280_simpletest.py
+++ b/examples/bmp280_simpletest.py
@@ -16,7 +16,7 @@ bmp280 = adafruit_bmp280.Adafruit_BMP280_I2C(i2c)
 
 # OR Create sensor object, communicating over the board's default SPI bus
 # spi = board.SPI()
-# bmp_cs = digitalio.DigitalInOut(board.D10)
+# bmp_cs = digitalio.DigitalInOut(board.D5)
 # bmp280 = adafruit_bmp280.Adafruit_BMP280_SPI(spi, bmp_cs)
 
 # change this to match the location's pressure (hPa) at sea level


### PR DESCRIPTION
@ladyada 
Resolves: #43 

The [guide page for BMP280](https://learn.adafruit.com/adafruit-bmp280-barometric-pressure-plus-temperature-sensor-breakout/circuitpython-test#step-2997178) shows CS wired to `D5`:
![image](https://github.com/user-attachments/assets/e55f89dd-5c87-4492-b3f9-be989889cb68)
![image](https://github.com/user-attachments/assets/00c856c5-ba1f-4b2b-a2aa-d236c765b262)

The code snippets on that page match the wiring images and use `D5`

However full example code at the bottom of the page is embedded from the simpletest in this repo and it has CS pin set to `D10` in the commented out section. 

This changes both examples to use pin `D5` for CS in the SPI setup section so that they will match the wiring and snippets shown on the guide page and updating it here will make the embedded version match the pin used on rest of the page.